### PR TITLE
fix: Correct LIFF environment variable usage

### DIFF
--- a/src/nextjs/next.config.js
+++ b/src/nextjs/next.config.js
@@ -1,6 +1,3 @@
 module.exports = {
   reactStrictMode: true,
-  env: {
-    LIFF_ID: process.env.LIFF_ID,
-  },
 };

--- a/src/nextjs/pages/_app.js
+++ b/src/nextjs/pages/_app.js
@@ -8,18 +8,19 @@ function MyApp({ Component, pageProps }) {
 
   // Execute liff.init() when the app is initialized
   useEffect(() => {
+    // to avoid sending error to Sentry
     console.log("start liff.init()...");
     liff
-      .init({ liffId: process.env.LIFF_ID })
+      .init({ liffId: process.env.NEXT_PUBLIC_LIFF_ID })
       .then(() => {
         console.log("liff.init() done");
         setLiffObject(liff);
       })
       .catch((error) => {
-        console.log(`liff.init() failed: ${error}`);
-        if (!process.env.liffId) {
+        console.error(`liff.init() failed: ${error}`);
+        if (!process.env.NEXT_PUBLIC_LIFF_ID) {
           console.info(
-            "LIFF Starter: Please make sure that you provided `LIFF_ID` as an environmental variable."
+            "LIFF Starter: Please make sure that you provided `NEXT_PUBLIC_LIFF_ID` as an environmental variable."
           );
         }
         setLiffError(error.toString());


### PR DESCRIPTION
This commit resolves the `liffId is necessary for liff.init()` error.

- The `env` block in `next.config.js` has been removed to standardize on using `.env.local` for environment variables.
- `_app.js` is updated to use `process.env.NEXT_PUBLIC_LIFF_ID`, which aligns with the variable set by the user in the Vercel deployment environment.
- The corresponding error message has also been updated to guide future debugging.

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 

Fixes # (issue)

## Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Code style update
- [ ] Refactor

If changing the UI of default theme, please provide the before/after screenshot.

# Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

If yes, please describe the impact.

# You have tested in the following environments: (Providing a detailed version will be better.)

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] Android
- [ ] iOS

# Final checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

# Other information
