### PR TITLE
fix: Use parameter-less liff.init for multi-LIFF support

### DIFF
--- a/src/nextjs/pages/_app.js
+++ b/src/nextjs/pages/_app.js
@@ -10,19 +10,17 @@ function MyApp({ Component, pageProps }) {
   useEffect(() => {
     // to avoid sending error to Sentry
     console.log("start liff.init()...");
+    // Calling liff.init() without a liffId allows the LIFF SDK to
+    // auto-detect the liffId from the URL it was launched with.
+    // This makes the app flexible for multiple LIFF apps.
     liff
-      .init({ liffId: process.env.NEXT_PUBLIC_LIFF_ID })
+      .init()
       .then(() => {
         console.log("liff.init() done");
         setLiffObject(liff);
       })
       .catch((error) => {
         console.error(`liff.init() failed: ${error}`);
-        if (!process.env.NEXT_PUBLIC_LIFF_ID) {
-          console.info(
-            "LIFF Starter: Please make sure that you provided `NEXT_PUBLIC_LIFF_ID` as an environmental variable."
-          );
-        }
         setLiffError(error.toString());
       });
   }, []);


### PR DESCRIPTION
This commit refactors the LIFF initialization logic in `_app.js`.

- The `liff.init()` call is now parameter-less. This allows the LIFF SDK to automatically detect the `liffId` from the context in which it was launched.
- This change enables the use of multiple LIFF apps (e.g., for registration, transport, cancellation) pointing to different pages within the same Next.js application, which was a key user requirement.
- The now-unnecessary `NEXT_PUBLIC_LIFF_ID` environment variable is no longer required for the application to function.

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 

Fixes # (issue)

## Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Code style update
- [ ] Refactor

If changing the UI of default theme, please provide the before/after screenshot.

# Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

If yes, please describe the impact.

# You have tested in the following environments: (Providing a detailed version will be better.)

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] Android
- [ ] iOS

# Final checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

# Other information
