### PR TITLE
fix: Pass empty object to liff.init to prevent TypeError

### DIFF
--- a/src/nextjs/pages/_app.js
+++ b/src/nextjs/pages/_app.js
@@ -10,11 +10,12 @@ function MyApp({ Component, pageProps }) {
   useEffect(() => {
     // to avoid sending error to Sentry
     console.log("start liff.init()...");
-    // Calling liff.init() without a liffId allows the LIFF SDK to
-    // auto-detect the liffId from the URL it was launched with.
-    // This makes the app flexible for multiple LIFF apps.
+    // Calling liff.init() with an empty object ensures that the function
+    // receives a defined object, preventing "Cannot read properties of undefined"
+    // errors in some versions of the LIFF SDK, while still allowing auto-detection
+    // of the liffId.
     liff
-      .init()
+      .init({})
       .then(() => {
         console.log("liff.init() done");
         setLiffObject(liff);


### PR DESCRIPTION
This commit resolves the `TypeError: Cannot read properties of undefined (reading 'liffId')` error that occurred during LIFF initialization.

The `liff.init()` call has been changed from `liff.init()` to `liff.init({})`.

This ensures that the `init` function always receives a defined object as its configuration parameter, preventing a potential TypeError in some versions of the LIFF SDK, while still allowing the SDK to automatically detect the LIFF ID from the launch URL.

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 

Fixes # (issue)

## Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Code style update
- [ ] Refactor

If changing the UI of default theme, please provide the before/after screenshot.

# Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

If yes, please describe the impact.

# You have tested in the following environments: (Providing a detailed version will be better.)

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] Android
- [ ] iOS

# Final checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

# Other information
