### PR TITLE
fix: Implement robust LIFF initialization logic

### DIFF
--- a/src/nextjs/pages/_app.js
+++ b/src/nextjs/pages/_app.js
@@ -8,14 +8,22 @@ function MyApp({ Component, pageProps }) {
 
   // Execute liff.init() when the app is initialized
   useEffect(() => {
-    // to avoid sending error to Sentry
     console.log("start liff.init()...");
-    // Calling liff.init() with an empty object ensures that the function
-    // receives a defined object, preventing "Cannot read properties of undefined"
-    // errors in some versions of the LIFF SDK, while still allowing auto-detection
-    // of the liffId.
+
+    // This new logic makes the app more robust.
+    // It uses an environment variable for the LIFF ID if it's provided,
+    // which is useful for local testing or single-LIFF deployments.
+    // If the variable is not set, it calls liff.init({}), allowing the
+    // SDK to auto-detect the LIFF ID when opened from a line://app/ URL.
+    // This supports the multi-LIFF app setup.
+    const liffId = process.env.NEXT_PUBLIC_LIFF_ID;
+    const initConfig = {};
+    if (liffId) {
+      initConfig.liffId = liffId;
+    }
+
     liff
-      .init({})
+      .init(initConfig)
       .then(() => {
         console.log("liff.init() done");
         setLiffObject(liff);


### PR DESCRIPTION
This commit refactors the LIFF initialization in `_app.js` to be more robust and prevent previous errors.

- The `liff.init()` call now uses a configuration object that is dynamically created.
- If the `NEXT_PUBLIC_LIFF_ID` environment variable is present, it will be used. This is useful for single-LIFF deployments or local testing.
- If the environment variable is not present, `liff.init({})` is called, allowing the SDK to auto-detect the LIFF ID from the launch URL. This supports the multi-LIFF app architecture.

This approach should prevent both the `liffId is necessary` and the `TypeError` seen previously, and provides maximum flexibility for deployment and testing.

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 

Fixes # (issue)

## Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Code style update
- [ ] Refactor

If changing the UI of default theme, please provide the before/after screenshot.

# Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

If yes, please describe the impact.

# You have tested in the following environments: (Providing a detailed version will be better.)

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] Android
- [ ] iOS

# Final checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

# Other information
