### PR TITLE
fix: Revert to parameter-less liff.init for auto-detection

### DIFF
--- a/src/nextjs/pages/_app.js
+++ b/src/nextjs/pages/_app.js
@@ -6,24 +6,14 @@ function MyApp({ Component, pageProps }) {
   const [liffObject, setLiffObject] = useState(null);
   const [liffError, setLiffError] = useState(null);
 
-  // Execute liff.init() when the app is initialized
   useEffect(() => {
     console.log("start liff.init()...");
-
-    // This new logic makes the app more robust.
-    // It uses an environment variable for the LIFF ID if it's provided,
-    // which is useful for local testing or single-LIFF deployments.
-    // If the variable is not set, it calls liff.init({}), allowing the
-    // SDK to auto-detect the LIFF ID when opened from a line://app/ URL.
-    // This supports the multi-LIFF app setup.
-    const liffId = process.env.NEXT_PUBLIC_LIFF_ID;
-    const initConfig = {};
-    if (liffId) {
-      initConfig.liffId = liffId;
-    }
-
+    // This is the cleanest approach for a multi-page LIFF app.
+    // Calling liff.init with an empty object allows the LIFF SDK to
+    // automatically detect the liffId from the URL it was launched with,
+    // without needing any environment variables.
     liff
-      .init(initConfig)
+      .init({})
       .then(() => {
         console.log("liff.init() done");
         setLiffObject(liff);
@@ -34,8 +24,6 @@ function MyApp({ Component, pageProps }) {
       });
   }, []);
 
-  // Provide `liff` object and `liffError` object
-  // to page component as property
   pageProps.liff = liffObject;
   pageProps.liffError = liffError;
   return <Component {...pageProps} />;


### PR DESCRIPTION
This commit reverts the LIFF initialization logic to the cleanest and most correct implementation for a multi-page LIFF application.

- The `liff.init()` call is now `liff.init({})`, which allows the LIFF SDK to automatically detect the `liffId` from the launch context.
- This removes the dependency on the `NEXT_PUBLIC_LIFF_ID` environment variable, which was causing issues when multiple LIFF apps were used.

This change is based on user feedback confirming that auto-detection works correctly when the app is launched properly.

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 

Fixes # (issue)

## Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Code style update
- [ ] Refactor

If changing the UI of default theme, please provide the before/after screenshot.

# Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

If yes, please describe the impact.

# You have tested in the following environments: (Providing a detailed version will be better.)

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] Android
- [ ] iOS

# Final checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

# Other information
