### PR TITLE
chore: Add diagnostic logging for LIFF initialization

### DIFF
--- a/src/nextjs/pages/_app.js
+++ b/src/nextjs/pages/_app.js
@@ -7,11 +7,20 @@ function MyApp({ Component, pageProps }) {
   const [liffError, setLiffError] = useState(null);
 
   useEffect(() => {
+    // Add diagnostic logs to debug initialization issues.
+    console.log("--- LIFF DIAGNOSTIC LOGS START ---");
+    try {
+      console.log("Current URL:", window.location.href);
+      console.log("LIFF is in client:", liff.isInClient());
+      console.log("LIFF OS:", liff.getOS());
+      console.log("LINE Version:", liff.getLineVersion());
+    } catch (e) {
+      console.error("Error getting initial LIFF state:", e);
+    }
+    console.log("--- LIFF DIAGNOSTIC LOGS END ---");
+
+
     console.log("start liff.init()...");
-    // This is the cleanest approach for a multi-page LIFF app.
-    // Calling liff.init with an empty object allows the LIFF SDK to
-    // automatically detect the liffId from the URL it was launched with,
-    // without needing any environment variables.
     liff
       .init({})
       .then(() => {


### PR DESCRIPTION
To debug a persistent `liffId is necessary for liff.init()` error, this commit adds several `console.log` statements to `_app.js`.

These logs will capture the state of the LIFF environment (URL, isInClient, OS, LINE version) just before `liff.init()` is called. This information is crucial for diagnosing why the LIFF SDK is failing to auto-detect the `liffId` in the user's specific mobile environment.

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 

Fixes # (issue)

## Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Code style update
- [ ] Refactor

If changing the UI of default theme, please provide the before/after screenshot.

# Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

If yes, please describe the impact.

# You have tested in the following environments: (Providing a detailed version will be better.)

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] Android
- [ ] iOS

# Final checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

# Other information
